### PR TITLE
Display counter damage in results

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "dependencies": {
     "bootstrap": "^4.3.1",
     "intro.js": "^2.9.3",
@@ -23,13 +24,14 @@
     "style-loader": "^3.3.4",
     "webpack": "^5.91.0",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^4.15.1"
+    "webpack-dev-server": "^4.15.1",
+    "jest": "^29.5.0"
   },
   "scripts": {
     "start": "webpack-dev-server --open",
     "dev": "webpack --config webpack.config.js",
     "build": "webpack --mode production --config webpack.config.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest --experimental-vm-modules"
   },
   "author": "",
   "license": "ISC"

--- a/src/services/damageService.js
+++ b/src/services/damageService.js
@@ -10,10 +10,11 @@ export default {
 };
 
 function detailedTotalDamageCalculation(
-	attackingHero,
-	defendingHero,
-	attackingUnit,
-	defendingUnit
+        attackingHero,
+        defendingHero,
+        attackingUnit,
+        defendingUnit,
+        includeCounter = true
 ) {
 	const attackerSpecialtyAttackBonus = calculateSpecialtyAttackBonus(
 		attackingHero,
@@ -120,21 +121,52 @@ function detailedTotalDamageCalculation(
 			(1 - airShieldSpellReduction);
 	}
 
-	const kills = calculateKills(
-		minTotalDamage,
-		maxTotalDamage,
-		defendingUnit.health
-	);
-	const rangedKills = calculateKills(
-		minTotalRangedDamage,
-		maxTotalRangedDamage,
-		defendingUnit.health
-	);
+        const kills = calculateKills(
+                minTotalDamage,
+                maxTotalDamage,
+                defendingUnit.health
+        );
+        const rangedKills = calculateKills(
+                minTotalRangedDamage,
+                maxTotalRangedDamage,
+                defendingUnit.health
+        );
 
-	return {
-		attackerCount: attackingUnit.count,
-		defenderCount: defendingUnit.count,
-		minTotalDamage,
+        let counterDamage = null;
+
+        if (includeCounter) {
+                const minSurvivors = Math.max(defendingUnit.count - kills.max, 0);
+                const maxSurvivors = Math.max(defendingUnit.count - kills.min, 0);
+
+                const minCounterResult = detailedTotalDamageCalculation(
+                        defendingHero,
+                        attackingHero,
+                        { ...defendingUnit, count: minSurvivors },
+                        attackingUnit,
+                        false
+                );
+                const maxCounterResult = detailedTotalDamageCalculation(
+                        defendingHero,
+                        attackingHero,
+                        { ...defendingUnit, count: maxSurvivors },
+                        attackingUnit,
+                        false
+                );
+
+                counterDamage = {
+                        minTotalDamage: minCounterResult.minTotalDamage,
+                        maxTotalDamage: maxCounterResult.maxTotalDamage,
+                        kills: {
+                                min: minCounterResult.kills.min,
+                                max: maxCounterResult.kills.max,
+                        },
+                };
+        }
+
+        return {
+                attackerCount: attackingUnit.count,
+                defenderCount: defendingUnit.count,
+                minTotalDamage,
 		maxTotalDamage,
 		minTotalRangedDamage,
 		maxTotalRangedDamage,
@@ -151,10 +183,11 @@ function detailedTotalDamageCalculation(
 		archerySpecialtyBonus: attackingHero.archerySpecialtyBonus,
 		defenseSkillReduction,
 		armorerReduction,
-		armorerSpecialityBonus,
-		meleePenaltyReduction,
-		slayerAttackBonus,
-	};
+                armorerSpecialityBonus,
+                meleePenaltyReduction,
+                slayerAttackBonus,
+                counterDamage,
+        };
 }
 
 /* eslint-disable-next-line consistent-return */

--- a/src/views/results.js
+++ b/src/views/results.js
@@ -3,11 +3,11 @@ export default class Results {
 		this.containerEl = document.getElementById(containerElId);
 	}
 
-	render(detailedDamageInfo) {
-		const {
-			minDamageText,
-			maxDamageText,
-			minTotalRangedDamage,
+        render(detailedDamageInfo) {
+                const {
+                        minDamageText,
+                        maxDamageText,
+                        minTotalRangedDamage,
 			maxTotalRangedDamage,
 			averageDamage,
 			averageRangedDamage,
@@ -21,21 +21,29 @@ export default class Results {
 			archeryBonus,
 			// archerySpecialtyBonus,
 			armorerSpecialityBonusHtml,
-			totalOffenseBonusText,
-			totalArmorerBonusText,
-			meleePenaltyReduction,
-		} = formatDamageOutput(detailedDamageInfo);
+                        totalOffenseBonusText,
+                        totalArmorerBonusText,
+                        meleePenaltyReduction,
+                        counterMinDamageText,
+                        counterMaxDamageText,
+                        counterAverageDamage,
+                        counterKills,
+                } = formatDamageOutput(detailedDamageInfo);
 
-		const headerData = {
-			minDamageText,
-			maxDamageText,
-			minTotalRangedDamage,
-			maxTotalRangedDamage,
-			averageDamage,
-			averageRangedDamage,
-			kills,
-			rangedKills,
-		};
+                const headerData = {
+                        minDamageText,
+                        maxDamageText,
+                        minTotalRangedDamage,
+                        maxTotalRangedDamage,
+                        averageDamage,
+                        averageRangedDamage,
+                        kills,
+                        rangedKills,
+                        counterMinDamageText,
+                        counterMaxDamageText,
+                        counterAverageDamage,
+                        counterKills,
+                };
 
 		this.containerEl.innerHTML = `
       ${createResultsHeader(headerData)}
@@ -63,24 +71,36 @@ export default class Results {
 }
 
 function createResultsHeader(detailedDamageInfo) {
-	const {
-		minDamageText,
-		maxDamageText,
-		averageDamage,
-		averageRangedDamage,
-		kills,
-		rangedKills,
-		minTotalRangedDamage,
-		maxTotalRangedDamage,
-	} = detailedDamageInfo;
+        const {
+                minDamageText,
+                maxDamageText,
+                averageDamage,
+                averageRangedDamage,
+                kills,
+                rangedKills,
+                minTotalRangedDamage,
+                maxTotalRangedDamage,
+                counterMinDamageText,
+                counterMaxDamageText,
+                counterAverageDamage,
+                counterKills,
+        } = detailedDamageInfo;
 
-	const meleeHeaderData = {
-		title: 'Melee damage',
-		minDamage: minDamageText,
-		maxDamage: maxDamageText,
-		averageDamage,
-		kills,
-	};
+        const meleeHeaderData = {
+                title: 'Melee damage',
+                minDamage: minDamageText,
+                maxDamage: maxDamageText,
+                averageDamage,
+                kills,
+        };
+
+        const counterHeaderData = {
+                title: 'Counter damage',
+                minDamage: counterMinDamageText,
+                maxDamage: counterMaxDamageText,
+                averageDamage: counterAverageDamage,
+                kills: counterKills,
+        };
 
 	const rangedHeaderData = {
 		title: 'Ranged damage',
@@ -90,14 +110,15 @@ function createResultsHeader(detailedDamageInfo) {
 		kills: rangedKills,
 	};
 
-	const meleeHeader = createResultsHeaderItem(meleeHeaderData);
-	let rangedHeader = '';
+        const meleeHeader = createResultsHeaderItem(meleeHeaderData);
+        let rangedHeader = '';
+        const counterHeader = createResultsHeaderItem(counterHeaderData);
 
 	if (maxTotalRangedDamage > 0) {
 		rangedHeader = createResultsHeaderItem(rangedHeaderData);
 	}
 
-	const headerHtml = rangedHeader + meleeHeader;
+        const headerHtml = rangedHeader + meleeHeader + counterHeader;
 
 	return `
     <div id="results-header">
@@ -133,22 +154,23 @@ function createResultsHeaderItem(damageDetails) {
 }
 
 function formatDamageOutput(detailedDamageInfo) {
-	const {
-		minTotalDamage,
-		maxTotalDamage,
-		kills,
-		minTotalRangedDamage,
-		maxTotalRangedDamage,
-		rangedKills,
-		attackSkillBonus,
-		offenseBonus,
-		offenseSpecialityBonus,
-		archeryBonus,
-		defenseSkillReduction,
-		armorerReduction,
-		armorerSpecialityBonus,
-		meleePenaltyReduction,
-	} = detailedDamageInfo;
+        const {
+                minTotalDamage,
+                maxTotalDamage,
+                kills,
+                minTotalRangedDamage,
+                maxTotalRangedDamage,
+                rangedKills,
+                attackSkillBonus,
+                offenseBonus,
+                offenseSpecialityBonus,
+                archeryBonus,
+                defenseSkillReduction,
+                armorerReduction,
+                armorerSpecialityBonus,
+                meleePenaltyReduction,
+                counterDamage,
+        } = detailedDamageInfo;
 
 	const minDamageText = Math.floor(minTotalDamage);
 	const maxDamageText = Math.floor(maxTotalDamage);
@@ -156,11 +178,25 @@ function formatDamageOutput(detailedDamageInfo) {
 		(detailedDamageInfo.minTotalDamage + detailedDamageInfo.maxTotalDamage) / 2
 	);
 
-	const averageRangedDamage = Math.floor(
-		(detailedDamageInfo.minTotalRangedDamage +
-			detailedDamageInfo.maxTotalRangedDamage) /
-			2
-	);
+        const averageRangedDamage = Math.floor(
+                (detailedDamageInfo.minTotalRangedDamage +
+                        detailedDamageInfo.maxTotalRangedDamage) /
+                        2
+        );
+
+        let counterMinDamageText = 0;
+        let counterMaxDamageText = 0;
+        let counterAverageDamage = 0;
+        let counterKills = { min: 0, max: 0 };
+
+        if (detailedDamageInfo.counterDamage) {
+                const { minTotalDamage: counterMin, maxTotalDamage: counterMax, kills: cKills } =
+                        detailedDamageInfo.counterDamage;
+                counterMinDamageText = Math.floor(counterMin);
+                counterMaxDamageText = Math.floor(counterMax);
+                counterAverageDamage = Math.floor((counterMin + counterMax) / 2);
+                counterKills = cKills;
+        }
 
 	const attackSkillBonusText = `${(attackSkillBonus * 100).toFixed(1)}`;
 	const defenseSkillBonusText = `${(defenseSkillReduction * 100).toFixed(1)}`;
@@ -204,8 +240,12 @@ function formatDamageOutput(detailedDamageInfo) {
 		armorerSpecialityBonusHtml,
 		totalOffenseBonus,
 		totalOffenseBonusText,
-		totalArmorerBonus,
-		totalArmorerBonusText,
-		meleePenaltyReduction,
-	};
+                totalArmorerBonus,
+                totalArmorerBonusText,
+                meleePenaltyReduction,
+                counterMinDamageText,
+                counterMaxDamageText,
+                counterAverageDamage,
+                counterKills,
+        };
 }

--- a/tests/damageService.test.js
+++ b/tests/damageService.test.js
@@ -1,0 +1,43 @@
+import damageService from '../src/services/damageService';
+import Hero from '../src/models/Hero';
+import unitService from '../src/services/unitService';
+
+describe('detailedTotalDamageCalculation', () => {
+  test('computes counter attack damage accounting for losses', () => {
+    const attackerHero = new Hero('A', 0, 0, 1, 'archers', {});
+    const defenderHero = new Hero('D', 0, 0, 1, 'archers', {});
+
+    const attackerUnit = { ...unitService.getUnit('PIKEMAN'), count: 10 };
+    const defenderUnit = { ...unitService.getUnit('GRIFFIN'), count: 10 };
+
+    const result = damageService.detailedTotalDamageCalculation(
+      attackerHero,
+      defenderHero,
+      attackerUnit,
+      defenderUnit
+    );
+
+    expect(result.counterDamage).not.toBeNull();
+    expect(result.counterDamage.minTotalDamage).toBeCloseTo(31.05);
+    expect(result.counterDamage.maxTotalDamage).toBeCloseTo(69);
+    expect(result.counterDamage.kills).toEqual({ min: 3, max: 6 });
+  });
+
+  test('returns null counter damage when disabled', () => {
+    const attackerHero = new Hero('A', 0, 0, 1, 'archers', {});
+    const defenderHero = new Hero('D', 0, 0, 1, 'archers', {});
+
+    const attackerUnit = { ...unitService.getUnit('PIKEMAN'), count: 10 };
+    const defenderUnit = { ...unitService.getUnit('GRIFFIN'), count: 10 };
+
+    const result = damageService.detailedTotalDamageCalculation(
+      attackerHero,
+      defenderHero,
+      attackerUnit,
+      defenderUnit,
+      false
+    );
+
+    expect(result.counterDamage).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- compute counter damage after melee attack accounting for unit losses
- show counter attack numbers under the Melee damage block
- add Jest-based unit tests for counter damage

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68710d51ff088325962a71a414c3c8de